### PR TITLE
Add codeberg.org as an alternative git host

### DIFF
--- a/src/countryMappings.json
+++ b/src/countryMappings.json
@@ -215,5 +215,23 @@
         "origin": "Germany"
       }
     ]
+  },
+  "github.com": {
+    "alternatives": [
+      {
+        "url": "codeberg.org",
+        "name": "Codeberg",
+        "origin": "Germany"
+      }
+    ]
+  },
+  "gitlab.com": {
+    "alternatives": [
+      {
+        "url": "codeberg.org",
+        "name": "Codeberg",
+        "origin": "Germany"
+      }
+    ]
   }
 }


### PR DESCRIPTION
Codeberg.org is a github/gitlab alternative based in Germany.
Source: The frontpage of the codeberg.org site.

Good alternative since it has a very similar UX to Github, but is fully open source.