### PR TITLE
Added slovenian alternative to amazon, Mimovrste.

### DIFF
--- a/src/countryMappings.json
+++ b/src/countryMappings.json
@@ -47,6 +47,11 @@
         "url": "bol.com",
         "name": "Bol",
         "origin": "Netherlands"
+      },
+      "Slovenia": {
+        "url": "mimovrste.com",
+        "name": "Mimovrste",
+        "origin": "Slovenia"
       }
     },
     "alternatives": [


### PR DESCRIPTION
This is the biggest online retailer in slovenia, basically the slovenian amazon. The company is based in slovenia, you can check out more information here:

https://www.mimovrste.com/kontakt

Also it was recently acquired by Allegro group which is already on this list.